### PR TITLE
Small changes for ergonimics and perf

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,12 @@ impl<T> GenomeMap<T> {
         self.sorted_keys.get(index).cloned()
     }
 
+    /// Return a reference (i.e. `&str`) to the name (e.g. chromosome or contig name) 
+    /// for the specified index. If not present, will return `None`. This is *O(1)*.
+    pub fn get_name_ref_by_index(&self, index: usize) -> Option<&str> {
+        self.sorted_keys.get(index).as_ref().map(|x| x.as_str())
+    }
+
     /// Return the index for a particular contig, by doing binary search.
     /// If the name is not found, returns `None`. This is *O(log(n))*
     /// where *n* is the number of elements.
@@ -169,8 +175,11 @@ impl<T> GenomeMap<T> {
     }
 
     /// Get the indices of the names (this is just `0..GenomeMap.len()`).
-    pub fn indices(&self) -> Vec<usize> {
-        Vec::from_iter(0..self.len())
+    pub fn indices(&self) -> std::ops::Range<usize> {
+        std::ops::Range {
+            start: 0,
+            end: self.len(),
+        }
     }
 
     /// O(1) check if a particular name is in the container.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ mod test {
         sm.insert("chr1", 1).unwrap();
         sm.insert("chr2", 2).unwrap();
 
-        assert_eq!(sm.indices(), vec![0, 1]);
+        assert_eq!(sm.indices(), 0..2);
 
         assert_eq!(sm.len(), 2);
         assert!(!sm.is_empty());
@@ -345,7 +345,7 @@ mod test {
         sm.insert("chr2", 1).unwrap();
         sm.insert("chr1", 2).unwrap();
 
-        assert_eq!(sm.indices(), vec![0, 1]);
+        assert_eq!(sm.indices(), 0..2);
     }
 
     #[test]


### PR DESCRIPTION
Of course, feel free to ignore if you think these don't make sense :).


Since the range of indices is always an actual range, the return type of the `indices` function was changed from `Vec<usize>` to a `Range<usize>` --- the user can trivially create the corresponding `Vec` from this if they wish.

Added a function to return a shared refernece to an underlying name (`&str`) rather than a clone of the name (`String`) which is kind of a micro optimization, but could avoid unnecessary allocations. The original function remains, however, in case the user wants an owned copy (one could also consider returing a CoW String).